### PR TITLE
Updated throttle README and tests to mirror Underscore-spec #3

### DIFF
--- a/throttle/README.md
+++ b/throttle/README.md
@@ -3,18 +3,20 @@ Here's the basic usage of the file that you'll be creating:
 ```js
 var throttle = require('./') // <- this is the file you make;
 
-var sayHi = function() {
-  console.log('hi');
+var log = function(msg) {
+  console.log(msg);
 };
 
-var throttled = throttle(sayHi, 100);
+var throttled = throttle(log, 100);
 
-throttled();
-throttled();
-throttled();
-throttled();
+throttled("First");
+throttled("Second");
+throttled("Third");
+throttled("Fourth");
 
-// there should only be one 'hi' message on the console
+// Output should be:
+// First
+// Fourth
 ```
 
 More info: http://underscorejs.org/#throttle

--- a/throttle/test.js
+++ b/throttle/test.js
@@ -2,7 +2,7 @@ var assert = require('assert');
 var throttle = require('./');
 
 describe('throttle', function() {
-  it("won't execute more than once within the threshold", function(done) {
+  it("will execute exactly twice in the threshold", function(done) {
     var called = 0;
     var throttled = throttle(function() {
       called++;
@@ -11,21 +11,22 @@ describe('throttle', function() {
     throttled();
     throttled();
     setTimeout(function() {
-      assert.equal(called, 1);
+      assert.equal(called, 2);
       done();
     }, 15);
   });
 
-  it("will execute more than once outside the threshold", function(done) {
+  it("will execute more than twice outside the threshold", function(done) {
     var called = 0;
     var throttled = throttle(function() {
       called++;
     }, 10);
     throttled();
+    throttled();
     setTimeout(throttled, 5);
     setTimeout(throttled, 20);
     setTimeout(function() {
-      assert.equal(called, 2);
+      assert.equal(called, 3);
       done();
     }, 35);
   });
@@ -36,11 +37,10 @@ describe('throttle', function() {
       ctx = this;
     }, 10);
     throttled.call(11);
-    throttled.call(22);
     setTimeout(function() {
-      assert.equal(ctx, 22);
+      assert.equal(ctx, 11);
       done();
-    }, 15)
+    }, 15);
   });
 
   it('gets called with arguments', function(done) {
@@ -49,12 +49,24 @@ describe('throttle', function() {
       args = [].slice.call(arguments);
     }, 10);
     throttled(11, 22, 33);
-    throttled(22, 33, 44);
     setTimeout(function() {
-      assert.deepEqual(args, [22, 33, 44]);
+      assert.deepEqual(args, [11, 22, 33]);
       done();
     }, 15);
   });
 
-
+  it('will fire the first and last function called within the threshold', function(done) {
+    var args = [];
+    var throttled = throttle(function() {
+      args.push( [].slice.call(arguments) );
+    }, 10);
+    throttled(11, 22, 33);
+    throttled(22, 33, 44);
+    throttled(33, 44, 55);
+    setTimeout(function() {
+      assert.deepEqual(args[0], [11, 22, 33]);
+      assert.deepEqual(args[1], [33, 44, 55]);
+      done();
+    }, 15);
+  });
 });


### PR DESCRIPTION
No matter how many calls are made in the threshold-period, only the first AND the last call should run.

Please note that this breaks the current solution.

An alternative to this would be to rename the throttle-challenge to debounce.
