### PR TITLE
Fixing debounce race-condition for timeouts

### DIFF
--- a/debounce/test.js
+++ b/debounce/test.js
@@ -37,7 +37,7 @@ describe('debounce', function() {
     setTimeout(function() {
       assert.equal(called, 2);
       done();
-    }, 35);
+    }, 45);
   });
 
   it('gets called with context', function(done) {


### PR DESCRIPTION
Currently, the first `debounce()`, takes 10secs to run. The second `debounce` in a `setTimeout(debounce, 20)` takes 30secs total (10 for the `debounce` and 20secs for the `setTimeout`). With the unreliability of `setTimeout` API, we end up having a race-condition, with the test failing (and occasionally passing). Pumping the timeout a few milliseconds solves this. I understand the two run parallel but I wouldn't rely on 5ms to know the difference.
