### PR TITLE
Minor fix for debounce test

### DIFF
--- a/debounce/test.js
+++ b/debounce/test.js
@@ -7,7 +7,6 @@ describe('debounce', function() {
     var debounced = debounce(function() {
       assert(new Date() - now > 10);
       done();
-      called++;
     }, 10);
     debounced();
   });

--- a/debounce/test.js
+++ b/debounce/test.js
@@ -5,7 +5,7 @@ describe('debounce', function() {
   it('waits for the threshold to pass before executing', function(done) {
     var now = new Date();
     var debounced = debounce(function() {
-      assert(new Date() - now > 10);
+      assert(new Date() - now >= 10);
       done();
     }, 10);
     debounced();


### PR DESCRIPTION
The test was checking for 11ms and in turn failing when debounce was running at its threshold (10ms). Also removed an unused variable increment.
