### PR TITLE
Adding test for curry, so it will also work with a single argument.

### DIFF
--- a/curry/test.js
+++ b/curry/test.js
@@ -10,6 +10,13 @@ describe('curry', function() {
     assert.equal(add(1)(2), 3);
   });
 
+  it('curries the function even with a single argument', function() {
+    var output = curry(function(n) {
+      return n;
+    });
+    assert.equal(output(1), 1);
+  });
+
   it('curries the function until the arguments needed are given at least once', function() {
     var add = curry(function(a, b, c) {
       return a + b + c;


### PR DESCRIPTION
test for the curry exercise for testing with a single argument, which could be easy forgotten when trying to save the state between curry calls.

for example if one will use the approach that the first call will create a new scope and return a function, this will work with the old tests, but not with the one i've added.

for ex:

``` js
function curry() {
    return function(input) { 
        // .. 
    }
}
```
