### PR TITLE
curry test for sharing state inside inner calls

### DIFF
--- a/curry/test.js
+++ b/curry/test.js
@@ -39,5 +39,14 @@ describe('curry', function() {
     assert.equal(add(2)(3)(4), 9);
   });
 
+  it("doesn't share state between inner calls", function() {
+    var add = curry(function(a, b, c, d) {
+        return a + b + c + d;
+    });
+    var firstTwo = add(1)(2);
+    assert.equal(firstTwo(3)(4), 10);
+    var firstThree = firstTwo(5);
+    assert.equal(firstThree(6), 14);
+  });
 
 });


### PR DESCRIPTION
curry should not share state even inside inner calls. 
