### PR TITLE
Fix 'once' test variable scope

### DIFF
--- a/once/test.js
+++ b/once/test.js
@@ -14,10 +14,9 @@ describe('once', function() {
   });
 
   it('will return the value from the original call for later calls', function() {
+    var t = 10;
     var init = once(function() {
-      var t = 10;
-      t++;
-      return t;
+      return ++t;
     });
     var ret = init();
     assert.deepEqual(init(), ret);


### PR DESCRIPTION
The test will pass even if function is ran more than once because the variable is declared inside the function scope. Moved the variable outside of the function scope.
