### PR TITLE
test that once returns the correct value

### DIFF
--- a/once/test.js
+++ b/once/test.js
@@ -19,6 +19,7 @@ describe('once', function() {
       return ++t;
     });
     var ret = init();
+    assert.deepEqual(ret, 11);
     assert.deepEqual(init(), ret);
     assert.deepEqual(init(), ret);
   });


### PR DESCRIPTION
## Problem

The tests for `once` currently pass if you create a solution that does not return anything.

For example, the following implementation passes even though it is broken.

It always returns `undefined`:

``` js
module.exports = once;

function once(fn) {
  var ran = false;
  return function() {
    if (!ran) {
      ran = true;
      fn.apply(this, arguments);
    }
  }
}
```
## Suggested Change

This change adds an assertion that verifies the implementation returns the correct value.
- `npm test` can pass if you use the faulty implementation above :open_mouth: 
- `npm test` will still pass using the solution on the `solutions` branch :+1:
