### PR TITLE
invert-tree: Add test cases for asymmetric trees

### DIFF
--- a/invert-tree/test.js
+++ b/invert-tree/test.js
@@ -3,7 +3,6 @@ var invertTree = require('./');
 
 describe('invert-tree', function() {
   it('inverts a binary tree', function() {
-
     var root = {value: 6};
     var left = {value: 4};
     var right = {value: 8};
@@ -41,7 +40,45 @@ describe('invert-tree', function() {
         }
       }
     });
+  });
 
+  it('inverts a right-leaning asymmetric tree', function() {
+    var root = {value: 4};
+    var right = {value: 6};
+    var rightOfRight = {value: 8};
+    root.right = right;
+    right.right = rightOfRight;
 
+    invertTree(root);
+
+    assert.deepEqual(root, {
+      "value": 4,
+      "left": {
+        "value": 6,
+        "left": {
+          value: 8
+        }
+      }
+    });
+  });
+
+  it('inverts a left-leaning asymmetric tree', function() {
+    var root = {value: 5};
+    var left = {value: 7};
+    var leftOfLeft = {value: 9};
+    root.left = left;
+    left.left = leftOfLeft;
+
+    invertTree(root);
+
+    assert.deepEqual(root, {
+      "value": 5,
+      "right": {
+        "value": 7,
+        "right": {
+          value: 9
+        }
+      }
+    });
   });
 });


### PR DESCRIPTION
My first attempt at this challenge takes a tree like this:

```
    A
   /
  B
```

and makes it into a tree like this:

```
    A
   / \
  B   B
```

when it should produce a tree like this:

```
    A
     \
      B
```

However, my flawed solution was passing the single test example that
currently exists for this challenge. I have added two test examples, one
for a left-leaning asymmetric tree and one for a right-leaning
asymmetric tree. These examples catch the type of flaw discussed above,
and should be helpful in encouraging/forcing challengers to clean up
after old child nodes.
