### PR TITLE
Ensure Date.now() isn't zero for throttle tests

### DIFF
--- a/throttle/test.js
+++ b/throttle/test.js
@@ -5,7 +5,7 @@ var throttle = require('./');
 describe('throttle', function() {
   var clock;
 
-  beforeEach(function () { clock = sinon.useFakeTimers(); });
+  beforeEach(function () { clock = sinon.useFakeTimers(Date.now()); });
   afterEach(function () { clock.restore(); });
 
   it('executes right away', function() {


### PR DESCRIPTION
Passes `Date.now()` to `sinon.useFakeTimers()` so that calling `Date.now()` inside the tests returns a realistic number and not zero. Fixes #40.
