### PR TITLE
Fix typo in the README of `binary-search` exercise

### DIFF
--- a/binary-search/README.md
+++ b/binary-search/README.md
@@ -5,7 +5,7 @@ The classic example given is looking for a name in a phonebook, you first look i
 Imagine a bunch of words in a list
 
 ```js
-['apple banana', 'cherry', 'dates', 'eggs', 'figs', 'grapes']
+['apple', 'banana', 'cherry', 'dates', 'eggs', 'figs', 'grapes']
 ```
 
 If we looks for `cherry` then we first look at the middle of the array we have:


### PR DESCRIPTION
There's a small typo in the README file of `binary-search` exercise, which is fixed by this PR.
