### PR TITLE
Additional test cases for async sequence

### DIFF
--- a/async/test.js
+++ b/async/test.js
@@ -18,6 +18,40 @@ describe('async', function() {
         done();
       });
     });
+
+    it('correctly handles sync functions in sequence', function(done) {
+      var fun1 = function(cb) {
+        cb(null, 'test1');
+      };
+      var fun2 = function(cb, data) {
+          cb(null, data);
+      };
+
+      // returns a thunk
+      async.sequence([fun1, fun2])(function(err, data) {
+        assert.equal(data, 'test1');
+        done();
+      });
+    });
+
+    it('handles delayed thunk invocation', function(done) {
+      var fun1 = function(cb) {
+        cb(null, 'test2');
+      };
+      var fun2 = function(cb, data) {
+        cb(null, data.toUpperCase());
+      };
+
+      // returns a thunk
+      var setter = async.sequence([fun1, fun2])
+
+      setTimeout(function() {
+        setter(function(err, data) {
+          assert.equal(data, 'TEST2');
+          done();
+        });
+      }, 100)
+    });
   });
 
   describe('has a parallel method that', function() {


### PR DESCRIPTION
Wrote a couple more tests to handle
- the case where the functions passed to `async.sequence` are themselves synchronous
- the case where the thunk returned from `async.sequence(...)` is invoked asynchronously
