### PR TITLE
Prevent a false correct case for async parallel

### DIFF
--- a/async/test.js
+++ b/async/test.js
@@ -57,7 +57,7 @@ describe('async', function() {
   describe('has a parallel method that', function() {
     it('runs functions in parallel', function(done) {
       var fun1 = function(cb) {
-        setTimeout(cb.bind(null, null, 'test'), 10);
+        setTimeout(cb.bind(null, null, 'test'), 20);
       };
       var fun2 = function(cb) {
         setTimeout(cb.bind(null, null, 'ing'), 10);


### PR DESCRIPTION
Current test case, all funcs have the same delay, it can be tricked by a loop calling all funcs. 

Increase the delay for 1st func will detect the false correct.